### PR TITLE
Fix row_idx bug in data_utils.py 

### DIFF
--- a/SAM-6D/Pose_Estimation_Model/utils/data_utils.py
+++ b/SAM-6D/Pose_Estimation_Model/utils/data_utils.py
@@ -117,9 +117,9 @@ def get_resize_rgb_choose(choose, bbox, img_size):
     crop_w = cmax - cmin
     ratio_w = img_size / crop_w
 
-    row_idx = choose // crop_h
-    col_idx = choose % crop_h
-    choose = (np.floor(row_idx * ratio_w) * img_size + np.floor(col_idx * ratio_h)).astype(np.int64)
+    row_idx = choose // crop_w
+    col_idx = choose % crop_w
+    choose = (np.floor(row_idx * ratio_h) * img_size + np.floor(col_idx * ratio_w)).astype(np.int64)
     return choose
 
 


### PR DESCRIPTION
The row_idx should be divided by width, not height. The scale factors for mapping back to the resized image should be switched.
Since the height and the width are the same in the cropped image and the resized image, this error has no negative impact on running in the current version.